### PR TITLE
mejoras en gameplay de movimiento y salto

### DIFF
--- a/FloorIsLava/Assets/Prefab/Player 2.prefab
+++ b/FloorIsLava/Assets/Prefab/Player 2.prefab
@@ -495,7 +495,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 80
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!65 &4129077945117915008
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/FloorIsLava/Assets/Scripts/RigidBodyMovement.cs
+++ b/FloorIsLava/Assets/Scripts/RigidBodyMovement.cs
@@ -23,7 +23,24 @@ public class RigidBodyMovement : MonoBehaviour
     [SerializeField]
     private float upForce = 290f;
     [SerializeField]
-    private float playerSpeed = 4f;
+    private float _playerSpeed = 4f;
+    
+    public bool IsDescending
+    {
+        get
+        {
+            return rb.velocity.y < 0;
+        }
+    }
+    public float PlayerSpeed
+    {
+        get
+        {
+            if (IsDescending) return _playerSpeed / 2;
+            return _playerSpeed;
+        }
+        private set { _playerSpeed = value; }
+    }
 
     public bool IsMovementAllowed
     {
@@ -47,7 +64,6 @@ public class RigidBodyMovement : MonoBehaviour
     {
         if (IsMovementAllowed)
         {
-            play.GetComponent<isGrounded>().CheckGround();
             anim.SetBool("IsRunning", false);
             Vector3 viewDir = player.position - new Vector3(transform.position.x, player.position.y, transform.position.z);
             orientation.forward = viewDir.normalized;
@@ -57,7 +73,7 @@ public class RigidBodyMovement : MonoBehaviour
             {
                 anim.SetBool("IsRunning", true);
                 playerObj.forward = Vector3.Slerp(playerObj.forward, inputDir.normalized, Time.deltaTime * rotationSpeed);
-                rb.MovePosition(player.position + inputDir * Time.deltaTime * playerSpeed);
+                rb.MovePosition(player.position + inputDir * Time.deltaTime * PlayerSpeed); 
             }
         }
     }
@@ -70,6 +86,7 @@ public class RigidBodyMovement : MonoBehaviour
             if (play.GetComponent<isGrounded>().grounded)
             {
                 rb.AddForce(Vector3.up * upForce);
+                anim.SetBool("Jumping", true);
             }
 
         }
@@ -78,7 +95,10 @@ public class RigidBodyMovement : MonoBehaviour
 
     private void setJumpingAnimation(bool isOnFloor)
     {
-        anim.SetBool("Jumping", !isOnFloor);
+        if(isOnFloor && anim.GetBool("Jumping") == true)
+        {
+            anim.SetBool("Jumping", !isOnFloor);
+        }
     }
 
     public void Pause()

--- a/FloorIsLava/Assets/Scripts/isGrounded.cs
+++ b/FloorIsLava/Assets/Scripts/isGrounded.cs
@@ -31,19 +31,25 @@ public class isGrounded : MonoBehaviour
 
     //}
 
-    public void CheckGround()
+    public void Update()
     {
         RaycastHit hit = new RaycastHit();
-        Debug.DrawRay(player.transform.position, Vector3.down * 0.6f, Color.green);
-        if (Physics.Raycast(player.transform.position, Vector3.down, out hit, 0.6f, layer))
+        Debug.DrawRay(player.transform.position, Vector3.down * 0.3f, Color.green);
+        if (Physics.Raycast(player.transform.position, Vector3.down, out hit, 0.3f, layer))
         {
-            grounded = true;
-            OnFloorCollisionChanged.Invoke(true);
-        }
-        else
+            if (!grounded)
+            {
+                grounded =! grounded;
+                OnFloorCollisionChanged.Invoke(true);
+            }
+
+        }else
         {
-            grounded = false;
-            OnFloorCollisionChanged.Invoke(false);
+            if (grounded)
+            {
+                grounded = !grounded;
+                OnFloorCollisionChanged.Invoke(false);
+            }
         }
     }
 

--- a/FloorIsLava/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/FloorIsLava/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -92,6 +92,11 @@
                 "value": "{\"m_Value\":false}"
             },
             {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "editor.stripProBuilderScriptsOnBuild",
+                "value": "{\"m_Value\":true}"
+            },
+            {
                 "type": "UnityEngine.ProBuilder.SelectMode, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "key": "editor.selectMode",
                 "value": "{\"m_Value\":1}"

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ classDiagram
         }
 		
 	class isGrounded{
-        +bool grounded
+        +bool grounded:serialized
         +UnityEvent<bool> OnFloorCollisionChanged
-	+GameObject player
-	-LayerMask layer
-	+CheckGround()
+	    +GameObject player:serialized
+	    -LayerMask layer:serialized
+	    +Update()
         
     }
 
@@ -96,13 +96,15 @@ classDiagram
         +Transform player
         +Transform playerObj
         +Rigidbody rb
-        +GameObject playe
+        +GameObject play
         -Animator anim:serialized
         -Vector2 input
         -PlayerInput playerInput
         +float rotationSpeed
         -float upForce:serialized
-        -float playerSpeed:serialized
+        -float _playerSpeed:serialized
+        +bool IsDescending:prop
+        +float PlayerSpeed:prop
         +bool IsMovementAllowed:prop
         -Start()
         -Update()


### PR DESCRIPTION
mejoras:
- prefab de player: collision de rb del pj ahora es continua
- al estar descendiendo luego de la cresta de un salto se reduce a la mitad la velocidad de movimiento en x-z

fixes:
-animacion de salto se ejecutaba al dejar grounded a pesar de no haber saltado 
-isGrounded invocaba el evento de unity en cada frame enviando un nuevo true o false incluso aunque antes fuera el mismo valor, ahora solo notifica si el valor cambia